### PR TITLE
SEGV in() Clipboard#getAvailableTypes

### DIFF
--- a/src/org/eclipse/swt/widgets/Display.d
+++ b/src/org/eclipse/swt/widgets/Display.d
@@ -3539,7 +3539,11 @@ public void setData (String key, Object value) {
     if (key.equals (DISPATCH_EVENT_KEY)) {
         ArrayWrapperInt wrappedValue;
         if (value is null || (null !is (wrappedValue=cast(ArrayWrapperInt)value))) {
-            dispatchEvents = wrappedValue.array;
+            if (wrappedValue is null) {
+                dispatchEvents = [];
+            } else {
+                dispatchEvents = wrappedValue.array;
+            }
             if (value is null) putGdkEvents ();
             return;
         }


### PR DESCRIPTION
Segmentation fault occurs in Clipboard#getAvailableTypes().

Clipboard#getAvailableTypes() is calling gtk_clipboard_wait_for_contents().
This code is contained in Clipboard#gtk_clipboard_wait_for_contents().

``` D
String key = "org.eclipse.swt.internal.gtk.dispatchEvent";
// snip
display.setData(key, null);
```

A null check in Display#setData() contains bug.
