### PR TITLE
FileDialog#SEPARATOR is mistaken.

### DIFF
--- a/src/org/eclipse/swt/widgets/DirectoryDialog.d
+++ b/src/org/eclipse/swt/widgets/DirectoryDialog.d
@@ -52,7 +52,7 @@ public class DirectoryDialog : Dialog {
     version(Tango){
         static const String SEPARATOR = tango.io.model.IFile.FileConst.PathSeparatorString;
     } else { // Phobos
-        static String SEPARATOR = std.path.pathSeparator;
+        static String SEPARATOR = std.path.dirSeparator;
     }
 
 /**

--- a/src/org/eclipse/swt/widgets/FileDialog.d
+++ b/src/org/eclipse/swt/widgets/FileDialog.d
@@ -60,7 +60,7 @@ public class FileDialog : Dialog {
     version(Tango){
         static const char SEPARATOR = tango.io.model.IFile.FileConst.PathSeparatorChar;
     } else { // Phobos
-        static const char SEPARATOR = std.path.pathSeparator[0];
+        static const char SEPARATOR = std.path.dirSeparator[0];
     }
     static const char EXTENSION_SEPARATOR = ';';
 


### PR DESCRIPTION
``` D
static const char SEPARATOR = std.path.pathSeparator[0];
```

This code is mistaken. (pathSeparator is ":")

Correctly:

``` D
static const char SEPARATOR = std.path.dirSeparator[0];
```

There is a same mistake to DirectoryDialog.
