### PR TITLE
make SWTMessagesBundleData static

### DIFF
--- a/src/org/eclipse/swt/internal/Compatibility.d
+++ b/src/org/eclipse/swt/internal/Compatibility.d
@@ -301,7 +301,7 @@ public static void exec(String[] progArray) {
     }
 }
 
-const ImportData[] SWTMessagesBundleData = [
+static const ImportData[] SWTMessagesBundleData = [
     getImportData!( "org.eclipse.swt.internal.SWTMessages.properties" ),
     getImportData!( "org.eclipse.swt.internal.SWTMessages_ar.properties" ),
     getImportData!( "org.eclipse.swt.internal.SWTMessages_cs.properties" ),


### PR DESCRIPTION
prevents an "Error: need 'this' for 'SWTMessagesBundleData'" message on compilation with dmd head master.
