### PR TITLE
Hack to make Library.di work

### DIFF
--- a/src/org/eclipse/swt/internal/Library.d
+++ b/src/org/eclipse/swt/internal/Library.d
@@ -16,8 +16,8 @@ import java.lang.all;
 
 // do it here, so it can be evaluated at compile time
 // this saves a static ctor.
-// T=bool hack to get body in to .di
-private int buildSWT_VERSION(T=bool) (int major, int minor) {
+// empty () hack to get body in to .di
+private int buildSWT_VERSION() (int major, int minor) {
     return major * 1000 + minor;
 }
 


### PR DESCRIPTION
without this, SWT_VERSION cannot be evaluated at compile time using only the .di file
