### PR TITLE
Fixes for V4 Bitmap reading.

### DIFF
--- a/src/org/eclipse/swt/internal/image/LEDataInputStream.d
+++ b/src/org/eclipse/swt/internal/image/LEDataInputStream.d
@@ -103,6 +103,16 @@ final class LEDataInputStream : InputStream{
         return read;
     }
 
+    public override long skip(long n) {
+        if (buf.length < position + n) {
+            n = buf.length - position;
+        }
+        pos += n;
+        position += n;
+        host.skip(n);
+        return n;
+    }
+
     /**
      * Reads at most <code>length</code> bytes from this LEDataInputStream and
      * stores them in byte array <code>buffer</code> starting at <code>offset</code>.

--- a/src/org/eclipse/swt/internal/image/WinBMPFileFormat.d
+++ b/src/org/eclipse/swt/internal/image/WinBMPFileFormat.d
@@ -440,11 +440,20 @@ override ImageData[] loadFromByteStream() {
     } catch (Exception e) {
         SWT.error(SWT.ERROR_IO, e);
     }
+    int headerSize = (infoHeader[0] & 0xFF) | ((infoHeader[1] & 0xFF) << 8) | ((infoHeader[2] & 0xFF) << 16) | ((infoHeader[3] & 0xFF) << 24);
     int width = (infoHeader[4] & 0xFF) | ((infoHeader[5] & 0xFF) << 8) | ((infoHeader[6] & 0xFF) << 16) | ((infoHeader[7] & 0xFF) << 24);
     int height = (infoHeader[8] & 0xFF) | ((infoHeader[9] & 0xFF) << 8) | ((infoHeader[10] & 0xFF) << 16) | ((infoHeader[11] & 0xFF) << 24);
     if (height < 0) height = -height;
     int bitCount = (infoHeader[14] & 0xFF) | ((infoHeader[15] & 0xFF) << 8);
     this.compression = (infoHeader[16] & 0xFF) | ((infoHeader[17] & 0xFF) << 8) | ((infoHeader[18] & 0xFF) << 16) | ((infoHeader[19] & 0xFF) << 24);
+    if (inputStream.getPosition() < (BMPFileHeaderSize + headerSize)) {
+        // Seek to the specified offset
+        try {
+            inputStream.skip((BMPFileHeaderSize + headerSize) - inputStream.getPosition());
+        } catch (IOException e) {
+            SWT.error(SWT.ERROR_IO, e);
+        }
+    }
     PaletteData palette = loadPalette(infoHeader);
     if (inputStream.getPosition() < fileHeader[4]) {
         // Seek to the specified offset


### PR DESCRIPTION
DWT doesn't support to Bitmap V4 and V5 Header now. This isn't a complete fix, but this will be read correctly a simple V4 or V5 bitmap.

See Also:
https://msdn.microsoft.com/en-us/library/dd183380%28v=vs.85%29.aspx
https://msdn.microsoft.com/en-us/library/dd183381%28VS.85%29.aspx